### PR TITLE
Remove unnecessary call to useDarkMode() in footer and hireme button

### DIFF
--- a/src/components/Buttons/HireMeBtn.js
+++ b/src/components/Buttons/HireMeBtn.js
@@ -1,9 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import useDarkMode from '../useDarkMode/useDarkMode';
 
 function HireMeBtn() {
-    useDarkMode();
 
     return (
         <Link to="/contact" className="relative p-0.5 inline-flex items-center justify-center font-bold overflow-hidden group rounded-md">

--- a/src/components/Footer/Footer.js
+++ b/src/components/Footer/Footer.js
@@ -1,10 +1,8 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import useDarkMode from '../useDarkMode/useDarkMode';
 import logo from '../Navbar/logo.png'
 
 function Footer() {
-    useDarkMode();
     return (
         <div className="bg-gray-900 dark:bg-gray-200 font-mono">
         <footer className="flex flex-wrap items-center justify-between p-3 m-auto">


### PR DESCRIPTION
I saw your question on the ZTM Discord and I figured this was easier than replying. The Footer.js and HiremeBtn.js both were calling useDarkMode() for some reason. Removing those calls fixes the issue with the application returning to dark mode on the main page.